### PR TITLE
Fixes missrotated sets of UUID for spying

### DIFF
--- a/src/main/java/world/bentobox/chat/listeners/ChatListener.java
+++ b/src/main/java/world/bentobox/chat/listeners/ChatListener.java
@@ -80,7 +80,7 @@ public class ChatListener implements Listener {
             }
             // Spy if required
             Bukkit.getOnlinePlayers().stream()
-            .filter(p -> spies.contains(p.getUniqueId()))
+            .filter(p -> islandSpies.contains(p.getUniqueId()))
             .map(User::getInstance)
             .forEach(a -> a.sendMessage("chat.team-chat.spy-syntax", TextVariables.NAME, player.getName(), "[message]", message));
         });
@@ -102,7 +102,7 @@ public class ChatListener implements Listener {
             }
             // Spy if required
             Bukkit.getOnlinePlayers().stream()
-            .filter(p -> islandSpies.contains(p.getUniqueId()))
+            .filter(p -> spies.contains(p.getUniqueId()))
             .map(User::getInstance)
             .forEach(u -> u.sendMessage("chat.team-chat.spy-syntax", TextVariables.NAME, player.getName(), "[message]", message));
         });


### PR DESCRIPTION
#islandChat method was checking the "spies" SET of UUID instead of it's own "islandSpies"
and
#teamChat method was checking "islandSpies"

Spy players were added in opposite sets leading to chat spying in a non-intended chat.