### PR TITLE
Reworks island chat, fixes bug, implements features

### DIFF
--- a/src/main/java/world/bentobox/chat/commands/island/IslandChatCommand.java
+++ b/src/main/java/world/bentobox/chat/commands/island/IslandChatCommand.java
@@ -30,11 +30,9 @@ public class IslandChatCommand extends CompositeCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        boolean is = false;
 
-        if(is = this.getIslands().getIslandAt(user.getLocation()).isPresent())
-            island = this.getIslands().getIslandAt(user.getLocation()).get();
-        return is;
+        island = this.getIslands().getIslandAt(user.getLocation()).orElse(null);
+        return island != null;
     }
 
     @Override

--- a/src/main/java/world/bentobox/chat/commands/island/IslandChatCommand.java
+++ b/src/main/java/world/bentobox/chat/commands/island/IslandChatCommand.java
@@ -30,15 +30,26 @@ public class IslandChatCommand extends CompositeCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        // TODO check rank
-        island = this.getIslands().getIsland(getWorld(), user);
-        return island != null;
+        boolean is = false;
+
+        if(is = this.getIslands().getIslandAt(user.getLocation()).isPresent())
+            island = this.getIslands().getIslandAt(user.getLocation()).get();
+        return is;
     }
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
         Chat addon = this.getAddon();
-        if (addon.getListener().toggleIslandChat(island)) {
+
+        // Send the message directly into island chat without the need of toggling it
+        // if there is existence of more arguments
+        if (args.size() > 0) {
+            addon.getListener().islandChat(island, user.getPlayer(), String.join(" ", args));
+            return true;
+        }
+
+
+        if (addon.getListener().toggleIslandChat(island, user.getPlayer())) {
             user.sendMessage("chat.island-chat.island-on");
         } else {
             user.sendMessage("chat.island-chat.island-off");

--- a/src/main/java/world/bentobox/chat/commands/island/IslandTeamChatCommand.java
+++ b/src/main/java/world/bentobox/chat/commands/island/IslandTeamChatCommand.java
@@ -13,7 +13,7 @@ import world.bentobox.chat.Chat;
 public class IslandTeamChatCommand extends CompositeCommand {
 
     public IslandTeamChatCommand(Addon addon, CompositeCommand parent, String label) {
-        super(addon, parent, label);
+        super(addon, parent, label, "tc");
     }
 
     @Override
@@ -36,6 +36,14 @@ public class IslandTeamChatCommand extends CompositeCommand {
     @Override
     public boolean execute(User user, String label, List<String> args) {
         Chat addon = this.getAddon();
+
+        // Send the message directly into team chat without the need of toggling it
+        // if there is existence of more arguments
+        if (args.size() > 0) {
+            addon.getListener().teamChat(user.getPlayer(), String.join(" ", args));
+            return true;
+        }
+
         if (addon.getListener().togglePlayerTeamChat(user.getUniqueId())) {
             user.sendMessage("chat.team-chat.chat-on");
         } else {

--- a/src/main/java/world/bentobox/chat/listeners/ChatListener.java
+++ b/src/main/java/world/bentobox/chat/listeners/ChatListener.java
@@ -1,9 +1,6 @@
 package world.bentobox.chat.listeners;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -29,7 +26,7 @@ public class ChatListener implements Listener {
 
     private final Chat addon;
     private final Set<UUID> teamChatUsers;
-    private final HashMap<Island, Set<Player>> islands;
+    private final Map<Island, Set<Player>> islands;
     // List of which users are spying or not on team and island chat
     private final Set<UUID> spies;
     private final Set<UUID> islandSpies;


### PR DESCRIPTION
- Reworks Island Chat to work as #11 explains
- Implements feature to send messages directly into teamchat or island chat via (/is tc or /is chat) without need of toggling if the command contains more arguments
- Adds "tc" as a command alias for teamchat, as people are used to it from ASkyBlock
- Fixes a bug when player was kept in TeamChat Set even after leaving/ being kicked from the island
