### PR TITLE
Implements option to change eventPriority of AsyncPlayerChatEvent via config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,15 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
+# Intellij
+*.iml
+*.java___jb_tmp___
+.idea/*
+*.ipr
+*.iws
+/out/
+.idea_modules/
+
 # Package Files #
 *.jar
 *.war

--- a/src/main/java/world/bentobox/chat/Chat.java
+++ b/src/main/java/world/bentobox/chat/Chat.java
@@ -3,8 +3,10 @@ package world.bentobox.chat;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.configuration.Config;
@@ -22,6 +24,7 @@ import world.bentobox.chat.requesthandlers.IsTeamChatHandler;
 public class Chat extends Addon {
 
     // Settings and configuration
+    public static Chat addon;
     private Settings settings;
     private Config<Settings> configObject = new Config<>(this, Settings.class);
     private Set<GameModeAddon> registeredGameModes;
@@ -29,6 +32,9 @@ public class Chat extends Addon {
 
     @Override
     public void onEnable() {
+
+        addon = this;
+
         /* Config */
         // Save default config from config.yml
         saveDefaultConfig();
@@ -42,6 +48,9 @@ public class Chat extends Addon {
 
         // Register listener
         listener = new ChatListener(this);
+        // This manually registers the AsyncPlayerChatEvent with the priority from configuration
+        Bukkit.getPluginManager().registerEvent(AsyncPlayerChatEvent.class, listener, getSettings().getEventPriority(), listener, getPlugin());
+        // This will register the remaining events with @EventHandler annotation inside the listener
         this.registerListener(listener);
 
         // Register request handlers

--- a/src/main/java/world/bentobox/chat/Settings.java
+++ b/src/main/java/world/bentobox/chat/Settings.java
@@ -1,5 +1,7 @@
 package world.bentobox.chat;
 
+import org.bukkit.event.Event;
+import org.bukkit.event.EventPriority;
 import world.bentobox.bentobox.api.configuration.ConfigComment;
 import world.bentobox.bentobox.api.configuration.ConfigEntry;
 import world.bentobox.bentobox.api.configuration.ConfigObject;
@@ -7,6 +9,7 @@ import world.bentobox.bentobox.api.configuration.StoreAt;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Contains the config settings for this addon.
@@ -31,7 +34,11 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "island-chat.log")
     private boolean logIslandChats;
 
-
+    @ConfigComment("Sets priority of AsyncPlayerChatEvent. Change this if Chat addon")
+    @ConfigComment("is conflicting with other plugins which listen to the same event")
+    @ConfigComment("Acceptable values: lowest, low, normal, high, highest, monitor")
+    @ConfigEntry(path = "chat-listener.priority")
+    private String eventPriority = "normal";
 
     public List<String> getTeamChatGamemodes() {
         return teamChatGamemodes;
@@ -75,5 +82,23 @@ public class Settings implements ConfigObject {
      */
     public void setLogIslandChats(boolean logIslandChats) {
         this.logIslandChats = logIslandChats;
+    }
+
+    public EventPriority getEventPriority() {
+
+        EventPriority priority = EventPriority.NORMAL;
+
+        try {
+            priority = EventPriority.valueOf(this.eventPriority.toUpperCase());
+        }
+        catch (IllegalArgumentException e){
+            Chat.addon.logError("EventPriority value: " + eventPriority + " is not valid in configuration. Using default: normal");
+        }
+
+        return priority;
+    }
+
+    public void setEventPriority(EventPriority eventPriority) {
+        this.eventPriority = eventPriority.toString();
     }
 }

--- a/src/main/java/world/bentobox/chat/listeners/ChatListener.java
+++ b/src/main/java/world/bentobox/chat/listeners/ChatListener.java
@@ -90,7 +90,7 @@ public class ChatListener implements Listener, EventExecutor {
     }
 
     // Removes player from TeamChat set if he left the island
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onLeave(TeamLeaveEvent e) {
 
         if (teamChatUsers.contains(e.getPlayerUUID()))
@@ -98,7 +98,7 @@ public class ChatListener implements Listener, EventExecutor {
     }
 
     // Removes player from TeamChat set if he was kicked from the island
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onKick(TeamKickEvent e) {
 
         if (teamChatUsers.contains(e.getPlayerUUID()))

--- a/src/main/java/world/bentobox/chat/listeners/ChatListener.java
+++ b/src/main/java/world/bentobox/chat/listeners/ChatListener.java
@@ -9,11 +9,13 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
+import org.bukkit.plugin.EventExecutor;
 import world.bentobox.bentobox.api.events.team.TeamKickEvent;
 import world.bentobox.bentobox.api.events.team.TeamLeaveEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -26,7 +28,7 @@ import world.bentobox.chat.Chat;
  * @author tastybento
  *
  */
-public class ChatListener implements Listener {
+public class ChatListener implements Listener, EventExecutor {
 
     private static final String MESSAGE = "[message]";
     private final Chat addon;
@@ -45,8 +47,19 @@ public class ChatListener implements Listener {
         islandSpies = new HashSet<>();
     }
 
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void execute(Listener listener, Event e) {
+
+        // Needs to be checked, as we manually registered the listener
+        // It's a replacement for ignoreCannceled = true
+        if (((AsyncPlayerChatEvent) e).isCancelled())
+            return;
+
+        // Call the event method
+        onChat((AsyncPlayerChatEvent) e);
+    }
+
     public void onChat(final AsyncPlayerChatEvent e) {
+
         Player p = e.getPlayer();
         World w = e.getPlayer().getWorld();
         // Check world

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,3 +16,8 @@ island-chat:
   - SkyGrid
   # Log island chats to console.
   log: false
+chat-listener:
+  # Sets priority of AsyncPlayerChatEvent. Change this if Chat addon
+  # is conflicting with other plugins which listen to the same event
+  # Acceptable values: lowest, low, normal, high, highest, monitor
+  priority: normal


### PR DESCRIPTION
This solves #24 @tastybento 

If one wishes to insert a priority of an event from a variable, the event cannot be registered via a standardly used #registerEvent**s** method, but rather manually with #registerEvent. The annotations will not accept the non-constant variables. 

Btw, I didn't remember of any better way to access the instance of Chat addon class, because I couldn't just send the object via the constructor of Settings itself as the Settings object is initialized with: `settings = configObject.loadConfigObject();`
If you have a better way, please change it.