### PR TITLE
fix(locale): quote cs.yml island-chat-spy syntax to fix malformed YAML

### DIFF
--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -25,4 +25,4 @@ chat:
       description: "Přepnout šmírování chatů na všech ostrovech"
       spy-on: <green>Šmírování chatů na ostrovech zapnuto</green>
       spy-off: <red>Šmírování chatů na ostrovech vypnuto</red>
-      syntax: <red>[island-chat-spy]</red> <dark_red>[name]</dark_red>: [message]
+      syntax: "<red>[island-chat-spy]</red> <dark_red>[name]</dark_red>: [message]"


### PR DESCRIPTION
## Summary

- The `island-chat-spy` syntax line in `cs.yml` was unquoted but contained `: ` (colon + space), which YAML treats as a mapping separator — causing a `ScannerException` on startup
- The equivalent `team-chat-spy` line on the same file was already correctly quoted; this brings `island-chat-spy` in line with it

Fixes https://github.com/BentoBoxWorld/BentoBox/issues/2953

## Test plan

- [ ] Start a server with this `cs.yml` in place — no YAML parse error on load
- [ ] Set locale to `cs`, use `/teamchatspy` and `/chatspy` — spy messages format correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)